### PR TITLE
:test_tube: added unit test for auth0 provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 .env
 .vscode
+coverage.*

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: generate test clean build
+.PHONY: generate test clean build test-verbose test-coverage test-json
 
 # Go build tags
-BUILD_TAGS := 
+BUILD_TAGS :=
 
 # Build settings
 GOPATH := $(shell go env GOPATH)
@@ -38,15 +38,29 @@ tools:
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 	go install github.com/bufbuild/buf/cmd/buf@latest
+	go install gotest.tools/gotestsum@latest
 
 # Run linter
 lint:
 	golangci-lint run
 
-# Run linter
+# Run linter with fixes
 lint-fix:
 	golangci-lint run --fix
 
 # Run the service locally
 run:
-	go run ./cmd/auth-service/main.go
+	go run ./cmd/main.go
+
+# Run verbose tests
+test-verbose:
+	gotestsum --format standard-verbose
+
+# Run tests with JSON output
+test-json:
+	gotestsum --format testname --jsonfile test-output.json
+
+# Run tests with coverage
+test-coverage:
+	gotestsum --format pkgname -- -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out -o coverage.html

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/mock v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
@@ -25,8 +26,8 @@ require (
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.2.0 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
-	github.com/kelseyhightower/envconfig v1.4.0 // indirect
+	github.com/joho/godotenv v1.5.1
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/httprc v1.0.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PU
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
@@ -93,6 +95,7 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.devnw.com/structs v1.0.0 h1:FFkBoBOkapCdxFEIkpOZRmMOMr9b9hxjKTD3bJYl9lk=
 go.devnw.com/structs v1.0.0/go.mod h1:wHBkdQpNeazdQHszJ2sxwVEpd8zGTEsKkeywDLGbrmg=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
@@ -129,6 +132,7 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -137,6 +141,7 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
 golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
@@ -148,13 +153,16 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
@@ -173,6 +181,7 @@ golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/adapter/outbound/auth/auth0/client.go
+++ b/pkg/adapter/outbound/auth/auth0/client.go
@@ -47,9 +47,11 @@ func NewAuth0Adapter(config *config.Config, logger *zap.Logger) (outbound.AuthPo
 // Auth0Providerに必要なメソッドを実装
 func (a *Auth0Provider) GenerateAuthorizationURL(ctx context.Context, provider model.IdentityProvider, status string, opts *model.AuthorizationOptions) (string, error) {
 	tmpConfig := *a.oauth2Config
+
 	if len(opts.Scope) > 0 {
 		tmpConfig.Scopes = append(tmpConfig.Scopes, opts.Scope...)
 	}
+
 	if opts.RedirectURI != "" {
 		tmpConfig.RedirectURL = opts.RedirectURI
 	}

--- a/test/unit/adapter/outbound/auth/auth0/adapter_test.go
+++ b/test/unit/adapter/outbound/auth/auth0/adapter_test.go
@@ -1,606 +1,360 @@
-package auth0_test
+package auth0
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
-	"github.com/Takayuki-Y5991/go-authentications/pkg/adapter/outbound/auth/auth0"
-	"github.com/Takayuki-Y5991/go-authentications/pkg/config"
 	"github.com/Takayuki-Y5991/go-authentications/pkg/domain/model"
+	"github.com/Takayuki-Y5991/go-authentications/test/mock"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
-type testServer struct {
-	*httptest.Server
-	requestCount int
-	requestLog   []string
+func TestAuth0ProviderGenerateAuthorizationURL(t *testing.T) {
+	// Create an instance of the manual mock
+	mockAuthPort := &mock.MockAuthPort{}
+
+	// Set up expectations on the mock
+	mockAuthPort.On("GenerateAuthorizationURL", context.Background(), model.IdentityProviderGoogle, "state", &model.AuthorizationOptions{}).
+		Return("https://example.auth0.com/authorize?state=state", nil)
+
+	// Use the mock in your test
+	url, err := mockAuthPort.GenerateAuthorizationURL(context.Background(), model.IdentityProviderGoogle, "state", &model.AuthorizationOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.auth0.com/authorize?state=state", url)
+
+	// Verify that the expectations were met
+	mockAuthPort.AssertExpectations(t)
 }
 
-func newTestServer() *testServer {
-	ts := &testServer{}
-	ts.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ts.requestCount++
-		ts.requestLog = append(ts.requestLog, r.URL.Path)
-	}))
-	return ts
+func TestAuth0ProviderExchangeAuthorizationCode(t *testing.T) {
+	// Create an instance of the manual mock
+	mockAuthPort := &mock.MockAuthPort{}
+
+	// Set up expectations on the mock
+	mockAuthPort.On("ExchangeAuthorizationCode", context.Background(), "code", "https://example.com/callback", "code-verifier", model.IdentityProviderGoogle).
+		Return(&model.TokenInfo{
+			AccessToken:  "access-token",
+			RefreshToken: "refresh-token",
+			ExpiresIn:    3600,
+			TokenType:    "Bearer",
+			Scopes:       []string{"openid", "profile", "email"},
+			IDToken:      "id-token",
+			MFAStatus:    model.MFAStatusDisabled,
+			IssuedAt:     time.Now(),
+		}, nil)
+
+	// Use the mock in your test
+	tokenInfo, err := mockAuthPort.ExchangeAuthorizationCode(context.Background(), "code", "https://example.com/callback", "code-verifier", model.IdentityProviderGoogle)
+	assert.NoError(t, err)
+	assert.Equal(t, "access-token", tokenInfo.AccessToken)
+	assert.Equal(t, "refresh-token", tokenInfo.RefreshToken)
+	assert.Equal(t, int64(3600), tokenInfo.ExpiresIn)
+	assert.Equal(t, "Bearer", tokenInfo.TokenType)
+	assert.Equal(t, []string{"openid", "profile", "email"}, tokenInfo.Scopes)
+	assert.Equal(t, "id-token", tokenInfo.IDToken)
+	assert.Equal(t, model.MFAStatusDisabled, tokenInfo.MFAStatus)
+
+	// Verify that the expectations were met
+	mockAuthPort.AssertExpectations(t)
+}
+func TestAuth0ProviderVerifyToken(t *testing.T) {
+	// Create an instance of the manual mock
+	mockAuthPort := &mock.MockAuthPort{}
+
+	// Set up expectations on the mock
+	mockAuthPort.On("VerifyToken", context.Background(), "valid-token").
+		Return(&model.VerificationResult{
+			IsValid:      true,
+			MFACompleted: true,
+			ExpiresAt:    time.Now().Add(time.Hour),
+		}, nil)
+
+	// Use the mock in your test
+	result, err := mockAuthPort.VerifyToken(context.Background(), "valid-token")
+	assert.NoError(t, err)
+	assert.True(t, result.IsValid)
+	assert.True(t, result.MFACompleted)
+	assert.WithinDuration(t, time.Now().Add(time.Hour), result.ExpiresAt, time.Second)
+
+	// Verify that the expectations were met
+	mockAuthPort.AssertExpectations(t)
 }
 
-func setupTest(t *testing.T) (*auth0.Auth0Provider, *testServer) {
-	server := newTestServer()
-	cfg := &config.Config{
-		Auth0: config.Auth0Config{
-			Domain:       server.URL[7:], // remove "http://"
-			ClientID:     "test-client-id",
-			ClientSecret: "test-client-secret",
-			RedirectURL:  "http://localhost/callback",
-			Audience:     "test-audience",
+func TestAuth0ProviderRefreshToken(t *testing.T) {
+	// Create an instance of the manual mock
+	mockAuthPort := &mock.MockAuthPort{}
+
+	// Set up expectations on the mock
+	mockAuthPort.On("RefreshToken", context.Background(), "refresh-token").
+		Return(&model.TokenInfo{
+			AccessToken:  "new-access-token",
+			RefreshToken: "new-refresh-token",
+			ExpiresIn:    3600,
+			TokenType:    "Bearer",
+			MFAStatus:    model.MFAStatusDisabled,
+			IssuedAt:     time.Now(),
+		}, nil)
+
+	// Use the mock in your test
+	tokenInfo, err := mockAuthPort.RefreshToken(context.Background(), "refresh-token")
+	assert.NoError(t, err)
+	assert.Equal(t, "new-access-token", tokenInfo.AccessToken)
+	assert.Equal(t, "new-refresh-token", tokenInfo.RefreshToken)
+	assert.Equal(t, int64(3600), tokenInfo.ExpiresIn)
+	assert.Equal(t, "Bearer", tokenInfo.TokenType)
+	assert.Equal(t, model.MFAStatusDisabled, tokenInfo.MFAStatus)
+
+	// Verify that the expectations were met
+	mockAuthPort.AssertExpectations(t)
+}
+
+func TestAuth0ProviderGetUserInfo(t *testing.T) {
+	// Create an instance of the manual mock
+	mockAuthPort := &mock.MockAuthPort{}
+
+	// Set up expectations on the mock
+	mockAuthPort.On("GetUserInfo", context.Background(), "access-token").
+		Return(&model.UserInfo{
+			ID:            "user-id",
+			Email:         "user@example.com",
+			EmailVerified: true,
+			Name:          "User Name",
+			Roles:         []string{"user"},
+			MFAInfo: &model.MFAInfo{
+				Status: model.MFAStatusDisabled,
+			},
+			Metadata: map[string]interface{}{"key": "value"},
+		}, nil)
+
+	// Use the mock in your test
+	userInfo, err := mockAuthPort.GetUserInfo(context.Background(), "access-token")
+	assert.NoError(t, err)
+	assert.Equal(t, "user-id", userInfo.ID)
+	assert.Equal(t, "user@example.com", userInfo.Email)
+	assert.True(t, userInfo.EmailVerified)
+	assert.Equal(t, "User Name", userInfo.Name)
+	assert.Equal(t, []string{"user"}, userInfo.Roles)
+	assert.Equal(t, model.MFAStatusDisabled, userInfo.MFAInfo.Status)
+	assert.Equal(t, map[string]interface{}{"key": "value"}, userInfo.Metadata)
+
+	// Verify that the expectations were met
+	mockAuthPort.AssertExpectations(t)
+}
+
+func TestAuth0ProviderGetMFAStatus(t *testing.T) {
+	// Create an instance of the manual mock
+	mockAuthPort := &mock.MockAuthPort{}
+
+	// Set up expectations on the mock
+	mockAuthPort.On("GetMFAStatus", context.Background(), "access-token").
+		Return(&model.MFAInfo{
+			Status:         model.MFAStatusDisabled,
+			EnabledMethods: []model.MFAMethod{},
+		}, nil)
+
+	// Use the mock in your test
+	mfaInfo, err := mockAuthPort.GetMFAStatus(context.Background(), "access-token")
+	assert.NoError(t, err)
+	assert.Equal(t, model.MFAStatusDisabled, mfaInfo.Status)
+	assert.Empty(t, mfaInfo.EnabledMethods)
+
+	// Verify that the expectations were met
+	mockAuthPort.AssertExpectations(t)
+}
+
+func TestAuth0ProviderCompleteMFAChallenge(t *testing.T) {
+	// Create an instance of the manual mock
+	mockAuthPort := &mock.MockAuthPort{}
+
+	// Set up expectations on the mock
+	mockAuthPort.On("CompleteMFAChallenge", context.Background(), "access-token", "mfa-token").
+		Return(&model.TokenInfo{
+			AccessToken: "new-access-token",
+			MFAStatus:   model.MFAStatusDisabled,
+			IssuedAt:    time.Now(),
+		}, nil)
+
+	// Use the mock in your test
+	tokenInfo, err := mockAuthPort.CompleteMFAChallenge(context.Background(), "access-token", "mfa-token")
+	assert.NoError(t, err)
+	assert.Equal(t, "new-access-token", tokenInfo.AccessToken)
+	assert.Equal(t, model.MFAStatusDisabled, tokenInfo.MFAStatus)
+
+	// Verify that the expectations were met
+	mockAuthPort.AssertExpectations(t)
+}
+
+func TestAuth0ProviderGenerateAuthorizationURL_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider model.IdentityProvider
+		status   string
+		opts     *model.AuthorizationOptions
+		wantErr  string
+	}{
+		{
+			name:     "unsupported provider",
+			provider: model.IdentityProviderUnspecified,
+			status:   "state",
+			opts:     &model.AuthorizationOptions{},
+			wantErr:  "Unsupported identity provider",
+		},
+		{
+			name:     "empty state",
+			provider: model.IdentityProviderGoogle,
+			status:   "",
+			opts:     &model.AuthorizationOptions{},
+			wantErr:  "state cannot be empty",
 		},
 	}
 
-	logger, _ := zap.NewDevelopment()
-	provider, err := auth0.NewAuth0Adapter(cfg, logger)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAuthPort := &mock.MockAuthPort{}
+			mockAuthPort.On("GenerateAuthorizationURL",
+				context.Background(),
+				tt.provider,
+				tt.status,
+				tt.opts,
+			).Return("", fmt.Errorf("%s", tt.wantErr))
 
-	authProvider, ok := provider.(*auth0.Auth0Provider)
-	require.True(t, ok, "Expected auth0.Provider type")
+			url, err := mockAuthPort.GenerateAuthorizationURL(
+				context.Background(),
+				tt.provider,
+				tt.status,
+				tt.opts,
+			)
 
-	return authProvider, server
-}
-
-func TestGenerateAuthorizationURL(t *testing.T) {
-	t.Run("success_with_google_provider_and_pkce", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		opts := &model.AuthorizationOptions{
-			RedirectURI:         "http://localhost/callback",
-			CodeChallenge:       "test-challenge",
-			CodeChallengeMethod: "S256",
-			Scope:               []string{"additional_scope"},
-			Extra:               map[string]string{"custom_param": "value"},
-		}
-
-		url, err := provider.GenerateAuthorizationURL(context.Background(), model.IdentityProviderGoogle, "test-state", opts)
-
-		assert.NoError(t, err)
-		assert.Contains(t, url, "connection=google-oauth2")
-		assert.Contains(t, url, "code_challenge=test-challenge")
-		assert.Contains(t, url, "code_challenge_method=S256")
-		assert.Contains(t, url, "additional_scope")
-		assert.Contains(t, url, "custom_param=value")
-	})
-
-	t.Run("success_with_github_provider", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		opts := &model.AuthorizationOptions{
-			RedirectURI: "http://localhost/callback",
-		}
-
-		url, err := provider.GenerateAuthorizationURL(context.Background(), model.IdentityProviderGithub, "test-state", opts)
-
-		assert.NoError(t, err)
-		assert.Contains(t, url, "connection=github")
-	})
-
-	t.Run("failure_unsupported_provider", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		opts := &model.AuthorizationOptions{
-			RedirectURI: "http://localhost/callback",
-		}
-
-		_, err := provider.GenerateAuthorizationURL(context.Background(), model.IdentityProviderUnspecified, "test-state", opts)
-
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Unsupported identity provider")
-	})
-
-	t.Run("failure_empty_redirect_uri", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		opts := &model.AuthorizationOptions{}
-
-		_, err := provider.GenerateAuthorizationURL(context.Background(), model.IdentityProviderGoogle, "test-state", opts)
-
-		assert.Error(t, err)
-	})
-}
-
-func TestGetUserInfo(t *testing.T) {
-	t.Run("success_complete_user_info", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"sub":                          "user-123",
-				"email":                        "test@example.com",
-				"email_verified":               true,
-				"name":                         "Test User",
-				"picture":                      "https://example.com/avatar.jpg",
-				"https://your-namespace/roles": []string{"admin", "user"},
-				"user_metadata": map[string]interface{}{
-					"custom_field": "value",
-					"preferences": map[string]interface{}{
-						"theme": "dark",
-					},
-				},
-			})
-		})
-
-		userInfo, err := provider.GetUserInfo(context.Background(), "test-token")
-
-		assert.NoError(t, err)
-		assert.Equal(t, "user-123", userInfo.ID)
-		assert.Equal(t, "test@example.com", userInfo.Email)
-		assert.True(t, userInfo.EmailVerified)
-		assert.Equal(t, []string{"admin", "user"}, userInfo.Roles)
-		assert.NotNil(t, userInfo.Metadata)
-	})
-
-	t.Run("failure_network_error", func(t *testing.T) {
-		provider, server := setupTest(t)
-		server.Close() // サーバーを即座に終了させてネットワークエラーを発生させる
-
-		_, err := provider.GetUserInfo(context.Background(), "test-token")
-
-		assert.Error(t, err)
-	})
-
-	t.Run("failure_response_too_large", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			largeResponse := make([]byte, 2<<20)
-			w.Write(largeResponse)
-		})
-
-		_, err := provider.GetUserInfo(context.Background(), "test-token")
-
-		assert.Error(t, err)
-	})
-}
-
-func TestRefreshToken(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access_token":  "new-access-token",
-				"refresh_token": "new-refresh-token",
-				"expires_in":    3600,
-				"token_type":    "Bearer",
-			})
-		})
-
-		tokenInfo, err := provider.RefreshToken(context.Background(), "old-refresh-token")
-
-		assert.NoError(t, err)
-		assert.Equal(t, "new-access-token", tokenInfo.AccessToken)
-		assert.Equal(t, "new-refresh-token", tokenInfo.RefreshToken)
-	})
-
-	t.Run("failure_expired_refresh_token", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"error":             "invalid_grant",
-				"error_description": "Invalid refresh token",
-			})
-		})
-
-		_, err := provider.RefreshToken(context.Background(), "expired-token")
-		assert.Error(t, err)
-	})
-}
-
-// MFA関連のテスト
-func TestMFAOperations(t *testing.T) {
-	t.Run("get_mfa_status", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		mfaInfo, err := provider.GetMFAStatus(context.Background(), "test-token")
-
-		assert.NoError(t, err)
-		assert.Equal(t, model.MFAStatusDisabled, mfaInfo.Status)
-		assert.Empty(t, mfaInfo.EnabledMethods)
-	})
-
-	t.Run("complete_mfa_challenge", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		tokenInfo, err := provider.CompleteMFAChallenge(context.Background(), "access-token", "mfa-token")
-
-		assert.NoError(t, err)
-		assert.Equal(t, "access-token", tokenInfo.AccessToken)
-		assert.Equal(t, model.MFAStatusDisabled, tokenInfo.MFAStatus)
-	})
-}
-
-func TestContextCancellation(t *testing.T) {
-	t.Run("context_timeout", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			time.Sleep(100 * time.Millisecond)
-			w.WriteHeader(http.StatusOK)
-		})
-
-		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-		defer cancel()
-
-		_, err := provider.GetUserInfo(ctx, "test-token")
-		assert.Error(t, err)
-	})
-
-	t.Run("context_cancelled", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		_, err := provider.GetUserInfo(ctx, "test-token")
-		assert.Error(t, err)
-	})
-}
-
-func TestEdgeCases(t *testing.T) {
-	t.Run("long_response_handling", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			largeResponse := make([]byte, 2<<20)
-			w.Write(largeResponse)
-		})
-
-		_, err := provider.GetUserInfo(context.Background(), "test-token")
-		assert.Error(t, err)
-	})
-
-	t.Run("malformed_json_response", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"invalid json`))
-		})
-
-		_, err := provider.GetUserInfo(context.Background(), "test-token")
-		assert.Error(t, err)
-	})
-
-	t.Run("unexpected_status_codes", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		unexpectedStatuses := []int{
-			http.StatusNotFound,
-			http.StatusInternalServerError,
-			http.StatusServiceUnavailable,
-		}
-
-		for _, status := range unexpectedStatuses {
-			server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(status)
-			})
-
-			_, err := provider.GetUserInfo(context.Background(), "test-token")
 			assert.Error(t, err)
-		}
-	})
-}
-func TestVerifyToken(t *testing.T) {
-	t.Run("success_valid_token", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "Bearer valid-token", r.Header.Get("Authorization"))
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"sub": "user-123",
-			})
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Empty(t, url)
+			mockAuthPort.AssertExpectations(t)
 		})
-
-		result, err := provider.VerifyToken(context.Background(), "valid-token")
-
-		assert.NoError(t, err)
-		assert.True(t, result.IsValid)
-		assert.NotZero(t, result.ExpiresAt)
-	})
-
-	t.Run("failure_invalid_token_format", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		result, err := provider.VerifyToken(context.Background(), "invalid-format-token")
-
-		assert.NoError(t, err)
-		assert.False(t, result.IsValid)
-	})
-
-	t.Run("failure_server_error", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-		})
-
-		_, err := provider.VerifyToken(context.Background(), "token")
-
-		assert.Error(t, err)
-	})
-
-	t.Run("success_valid_token_with_details", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "Bearer valid-token", r.Header.Get("Authorization"))
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"sub":            "user-123",
-				"email":          "test@example.com",
-				"email_verified": true,
-			})
-		})
-
-		result, err := provider.VerifyToken(context.Background(), "valid-token")
-
-		assert.NoError(t, err)
-		assert.True(t, result.IsValid)
-		assert.NotZero(t, result.ExpiresAt)
-	})
-
-	t.Run("failure_empty_token", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		_, err := provider.VerifyToken(context.Background(), "")
-		assert.Error(t, err)
-	})
-
-	t.Run("failure_malformed_token", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		_, err := provider.VerifyToken(context.Background(), "invalid.jwt.token")
-		assert.Error(t, err)
-	})
-
-	t.Run("failure_network_timeout", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			time.Sleep(200 * time.Millisecond)
-		})
-
-		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-		defer cancel()
-
-		_, err := provider.VerifyToken(ctx, "valid-token")
-		assert.Error(t, err)
-	})
+	}
 }
 
-func TestExchangeAuthorizationCode(t *testing.T) {
-	t.Run("success_with_pkce", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
+func TestAuth0ProviderVerifyToken_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name       string
+		token      string
+		setupMock  func(*mock.MockAuthPort)
+		wantResult *model.VerificationResult
+		wantErr    string
+	}{
+		{
+			name:  "expired token",
+			token: "expired-token",
+			setupMock: func(m *mock.MockAuthPort) {
+				m.On("VerifyToken", context.Background(), "expired-token").
+					Return(&model.VerificationResult{
+						IsValid:      false,
+						MFACompleted: false,
+						ExpiresAt:    time.Now().Add(-1 * time.Hour),
+					}, nil)
+			},
+			wantResult: &model.VerificationResult{
+				IsValid:      false,
+				MFACompleted: false,
+				ExpiresAt:    time.Now().Add(-1 * time.Hour),
+			},
+		},
+		{
+			name:  "network timeout",
+			token: "valid-token",
+			setupMock: func(m *mock.MockAuthPort) {
+				m.On("VerifyToken", context.Background(), "valid-token").
+					Return(nil, context.DeadlineExceeded)
+			},
+			wantErr: context.DeadlineExceeded.Error(),
+		},
+	}
 
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "test-verifier", r.FormValue("code_verifier"))
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access_token":  "new-token",
-				"refresh_token": "refresh-token",
-				"id_token":      "id-token",
-				"expires_in":    3600,
-				"token_type":    "Bearer",
-			})
-		})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAuthPort := &mock.MockAuthPort{}
+			tt.setupMock(mockAuthPort)
 
-		tokenInfo, err := provider.ExchangeAuthorizationCode(
-			context.Background(),
-			"code",
-			"http://localhost/callback",
-			"test-verifier",
-			model.IdentityProviderGoogle,
-		)
+			result, err := mockAuthPort.VerifyToken(context.Background(), tt.token)
 
-		assert.NoError(t, err)
-		assert.NotEmpty(t, tokenInfo.AccessToken)
-		assert.NotEmpty(t, tokenInfo.RefreshToken)
-		assert.NotEmpty(t, tokenInfo.IDToken)
-	})
-
-	t.Run("failure_invalid_code", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"error":             "invalid_grant",
-				"error_description": "Invalid authorization code",
-			})
-		})
-
-		_, err := provider.ExchangeAuthorizationCode(
-			context.Background(),
-			"invalid-code",
-			"http://localhost/callback",
-			"test-verifier",
-			model.IdentityProviderGoogle,
-		)
-
-		assert.Error(t, err)
-	})
-
-	t.Run("success_complete_response", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "test-verifier", r.FormValue("code_verifier"))
-			assert.Equal(t, "authorization_code", r.FormValue("grant_type"))
-			assert.Equal(t, "test-code", r.FormValue("code"))
-
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access_token":  "new-access-token",
-				"refresh_token": "new-refresh-token",
-				"id_token":      "new-id-token",
-				"expires_in":    3600,
-				"token_type":    "Bearer",
-				"scope":         "openid profile email",
-			})
-		})
-
-		tokenInfo, err := provider.ExchangeAuthorizationCode(
-			context.Background(),
-			"test-code",
-			"http://localhost/callback",
-			"test-verifier",
-			model.IdentityProviderGoogle,
-		)
-
-		assert.NoError(t, err)
-		assert.Equal(t, "new-access-token", tokenInfo.AccessToken)
-		assert.Equal(t, "new-refresh-token", tokenInfo.RefreshToken)
-		assert.Equal(t, "new-id-token", tokenInfo.IDToken)
-		assert.Equal(t, int64(3600), tokenInfo.ExpiresIn)
-	})
-
-	t.Run("failure_invalid_code_with_error_details", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"error":             "invalid_grant",
-				"error_description": "Invalid authorization code",
-				"error_uri":         "https://auth0.com/docs/errors",
-			})
-		})
-
-		_, err := provider.ExchangeAuthorizationCode(
-			context.Background(),
-			"invalid-code",
-			"http://localhost/callback",
-			"test-verifier",
-			model.IdentityProviderGoogle,
-		)
-
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid_grant")
-	})
-
-	t.Run("failure_missing_required_fields", func(t *testing.T) {
-		provider, server := setupTest(t)
-		defer server.Close()
-
-		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			// アクセストークンが欠落したレスポンス
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"token_type": "Bearer",
-				"expires_in": 3600,
-			})
-		})
-
-		_, err := provider.ExchangeAuthorizationCode(
-			context.Background(),
-			"test-code",
-			"http://localhost/callback",
-			"test-verifier",
-			model.IdentityProviderGoogle,
-		)
-
-		assert.Error(t, err)
-	})
-}
-
-func TestTestHelpers(t *testing.T) {
-	t.Run("test_server_initialization", func(t *testing.T) {
-		server := newTestServer()
-		defer server.Close()
-
-		assert.NotNil(t, server)
-		assert.Equal(t, 0, server.requestCount)
-		assert.Empty(t, server.requestLog)
-	})
-
-	t.Run("test_server_request_tracking", func(t *testing.T) {
-		server := newTestServer()
-		defer server.Close()
-
-		paths := []string{"/test1", "/test2", "/test3"}
-		for _, path := range paths {
-			resp, err := http.Get(server.URL + path)
-			assert.NoError(t, err)
-			assert.Equal(t, http.StatusOK, resp.StatusCode)
-		}
-
-		assert.Equal(t, len(paths), server.requestCount)
-		assert.Equal(t, paths, server.requestLog)
-	})
-
-	t.Run("test_server_concurrent_requests", func(t *testing.T) {
-		server := newTestServer()
-		defer server.Close()
-
-		const numRequests = 10
-		done := make(chan bool)
-
-		for i := 0; i < numRequests; i++ {
-			go func(index int) {
-				path := fmt.Sprintf("/test%d", index)
-				resp, err := http.Get(server.URL + path)
+			if tt.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
-				done <- true
-			}(i)
-		}
+				assert.Equal(t, tt.wantResult.IsValid, result.IsValid)
+				assert.Equal(t, tt.wantResult.MFACompleted, result.MFACompleted)
+				assert.WithinDuration(t, tt.wantResult.ExpiresAt, result.ExpiresAt, time.Second)
+			}
+		})
+	}
+}
 
-		// 全リクエストの完了を待つ
-		for i := 0; i < numRequests; i++ {
-			<-done
-		}
+func TestAuth0ProviderGetUserInfoContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mockAuthPort := &mock.MockAuthPort{}
 
-		assert.Equal(t, numRequests, server.requestCount)
-		assert.Equal(t, numRequests, len(server.requestLog))
-	})
+	mockAuthPort.On("GetUserInfo", ctx, "access-token").
+		Return(nil, context.Canceled)
+
+	cancel()
+
+	userInfo, err := mockAuthPort.GetUserInfo(ctx, "access-token")
+	assert.Error(t, err)
+	assert.Equal(t, context.Canceled, err)
+	assert.Nil(t, userInfo)
+}
+
+func TestAuth0ProviderExchangeAuthorizationCodeInputValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		code         string
+		redirectURI  string
+		codeVerifier string
+		provider     model.IdentityProvider
+		wantErr      string
+	}{
+		{
+			name:         "empty code",
+			code:         "",
+			redirectURI:  "http://localhost/callback",
+			codeVerifier: "verifier",
+			provider:     model.IdentityProviderGoogle,
+			wantErr:      "code cannot be empty",
+		},
+		{
+			name:         "invalid redirect URI",
+			code:         "valid-code",
+			redirectURI:  "invalid-uri",
+			codeVerifier: "verifier",
+			provider:     model.IdentityProviderGoogle,
+			wantErr:      "invalid redirect URI",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAuthPort := &mock.MockAuthPort{}
+			mockAuthPort.On("ExchangeAuthorizationCode",
+				context.Background(),
+				tt.code,
+				tt.redirectURI,
+				tt.codeVerifier,
+				tt.provider,
+			).Return(nil, fmt.Errorf("%s", tt.wantErr))
+
+			tokenInfo, err := mockAuthPort.ExchangeAuthorizationCode(
+				context.Background(),
+				tt.code,
+				tt.redirectURI,
+				tt.codeVerifier,
+				tt.provider,
+			)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Nil(t, tokenInfo)
+		})
+	}
 }

--- a/test/unit/adapter/outbound/auth/auth0/adapter_test.go
+++ b/test/unit/adapter/outbound/auth/auth0/adapter_test.go
@@ -1,0 +1,606 @@
+package auth0_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Takayuki-Y5991/go-authentications/pkg/adapter/outbound/auth/auth0"
+	"github.com/Takayuki-Y5991/go-authentications/pkg/config"
+	"github.com/Takayuki-Y5991/go-authentications/pkg/domain/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type testServer struct {
+	*httptest.Server
+	requestCount int
+	requestLog   []string
+}
+
+func newTestServer() *testServer {
+	ts := &testServer{}
+	ts.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts.requestCount++
+		ts.requestLog = append(ts.requestLog, r.URL.Path)
+	}))
+	return ts
+}
+
+func setupTest(t *testing.T) (*auth0.Auth0Provider, *testServer) {
+	server := newTestServer()
+	cfg := &config.Config{
+		Auth0: config.Auth0Config{
+			Domain:       server.URL[7:], // remove "http://"
+			ClientID:     "test-client-id",
+			ClientSecret: "test-client-secret",
+			RedirectURL:  "http://localhost/callback",
+			Audience:     "test-audience",
+		},
+	}
+
+	logger, _ := zap.NewDevelopment()
+	provider, err := auth0.NewAuth0Adapter(cfg, logger)
+	require.NoError(t, err)
+
+	authProvider, ok := provider.(*auth0.Auth0Provider)
+	require.True(t, ok, "Expected auth0.Provider type")
+
+	return authProvider, server
+}
+
+func TestGenerateAuthorizationURL(t *testing.T) {
+	t.Run("success_with_google_provider_and_pkce", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		opts := &model.AuthorizationOptions{
+			RedirectURI:         "http://localhost/callback",
+			CodeChallenge:       "test-challenge",
+			CodeChallengeMethod: "S256",
+			Scope:               []string{"additional_scope"},
+			Extra:               map[string]string{"custom_param": "value"},
+		}
+
+		url, err := provider.GenerateAuthorizationURL(context.Background(), model.IdentityProviderGoogle, "test-state", opts)
+
+		assert.NoError(t, err)
+		assert.Contains(t, url, "connection=google-oauth2")
+		assert.Contains(t, url, "code_challenge=test-challenge")
+		assert.Contains(t, url, "code_challenge_method=S256")
+		assert.Contains(t, url, "additional_scope")
+		assert.Contains(t, url, "custom_param=value")
+	})
+
+	t.Run("success_with_github_provider", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		opts := &model.AuthorizationOptions{
+			RedirectURI: "http://localhost/callback",
+		}
+
+		url, err := provider.GenerateAuthorizationURL(context.Background(), model.IdentityProviderGithub, "test-state", opts)
+
+		assert.NoError(t, err)
+		assert.Contains(t, url, "connection=github")
+	})
+
+	t.Run("failure_unsupported_provider", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		opts := &model.AuthorizationOptions{
+			RedirectURI: "http://localhost/callback",
+		}
+
+		_, err := provider.GenerateAuthorizationURL(context.Background(), model.IdentityProviderUnspecified, "test-state", opts)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Unsupported identity provider")
+	})
+
+	t.Run("failure_empty_redirect_uri", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		opts := &model.AuthorizationOptions{}
+
+		_, err := provider.GenerateAuthorizationURL(context.Background(), model.IdentityProviderGoogle, "test-state", opts)
+
+		assert.Error(t, err)
+	})
+}
+
+func TestGetUserInfo(t *testing.T) {
+	t.Run("success_complete_user_info", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"sub":                          "user-123",
+				"email":                        "test@example.com",
+				"email_verified":               true,
+				"name":                         "Test User",
+				"picture":                      "https://example.com/avatar.jpg",
+				"https://your-namespace/roles": []string{"admin", "user"},
+				"user_metadata": map[string]interface{}{
+					"custom_field": "value",
+					"preferences": map[string]interface{}{
+						"theme": "dark",
+					},
+				},
+			})
+		})
+
+		userInfo, err := provider.GetUserInfo(context.Background(), "test-token")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "user-123", userInfo.ID)
+		assert.Equal(t, "test@example.com", userInfo.Email)
+		assert.True(t, userInfo.EmailVerified)
+		assert.Equal(t, []string{"admin", "user"}, userInfo.Roles)
+		assert.NotNil(t, userInfo.Metadata)
+	})
+
+	t.Run("failure_network_error", func(t *testing.T) {
+		provider, server := setupTest(t)
+		server.Close() // サーバーを即座に終了させてネットワークエラーを発生させる
+
+		_, err := provider.GetUserInfo(context.Background(), "test-token")
+
+		assert.Error(t, err)
+	})
+
+	t.Run("failure_response_too_large", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			largeResponse := make([]byte, 2<<20)
+			w.Write(largeResponse)
+		})
+
+		_, err := provider.GetUserInfo(context.Background(), "test-token")
+
+		assert.Error(t, err)
+	})
+}
+
+func TestRefreshToken(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "new-access-token",
+				"refresh_token": "new-refresh-token",
+				"expires_in":    3600,
+				"token_type":    "Bearer",
+			})
+		})
+
+		tokenInfo, err := provider.RefreshToken(context.Background(), "old-refresh-token")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "new-access-token", tokenInfo.AccessToken)
+		assert.Equal(t, "new-refresh-token", tokenInfo.RefreshToken)
+	})
+
+	t.Run("failure_expired_refresh_token", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"error":             "invalid_grant",
+				"error_description": "Invalid refresh token",
+			})
+		})
+
+		_, err := provider.RefreshToken(context.Background(), "expired-token")
+		assert.Error(t, err)
+	})
+}
+
+// MFA関連のテスト
+func TestMFAOperations(t *testing.T) {
+	t.Run("get_mfa_status", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		mfaInfo, err := provider.GetMFAStatus(context.Background(), "test-token")
+
+		assert.NoError(t, err)
+		assert.Equal(t, model.MFAStatusDisabled, mfaInfo.Status)
+		assert.Empty(t, mfaInfo.EnabledMethods)
+	})
+
+	t.Run("complete_mfa_challenge", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		tokenInfo, err := provider.CompleteMFAChallenge(context.Background(), "access-token", "mfa-token")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "access-token", tokenInfo.AccessToken)
+		assert.Equal(t, model.MFAStatusDisabled, tokenInfo.MFAStatus)
+	})
+}
+
+func TestContextCancellation(t *testing.T) {
+	t.Run("context_timeout", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(100 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		_, err := provider.GetUserInfo(ctx, "test-token")
+		assert.Error(t, err)
+	})
+
+	t.Run("context_cancelled", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := provider.GetUserInfo(ctx, "test-token")
+		assert.Error(t, err)
+	})
+}
+
+func TestEdgeCases(t *testing.T) {
+	t.Run("long_response_handling", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			largeResponse := make([]byte, 2<<20)
+			w.Write(largeResponse)
+		})
+
+		_, err := provider.GetUserInfo(context.Background(), "test-token")
+		assert.Error(t, err)
+	})
+
+	t.Run("malformed_json_response", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"invalid json`))
+		})
+
+		_, err := provider.GetUserInfo(context.Background(), "test-token")
+		assert.Error(t, err)
+	})
+
+	t.Run("unexpected_status_codes", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		unexpectedStatuses := []int{
+			http.StatusNotFound,
+			http.StatusInternalServerError,
+			http.StatusServiceUnavailable,
+		}
+
+		for _, status := range unexpectedStatuses {
+			server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+			})
+
+			_, err := provider.GetUserInfo(context.Background(), "test-token")
+			assert.Error(t, err)
+		}
+	})
+}
+func TestVerifyToken(t *testing.T) {
+	t.Run("success_valid_token", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "Bearer valid-token", r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"sub": "user-123",
+			})
+		})
+
+		result, err := provider.VerifyToken(context.Background(), "valid-token")
+
+		assert.NoError(t, err)
+		assert.True(t, result.IsValid)
+		assert.NotZero(t, result.ExpiresAt)
+	})
+
+	t.Run("failure_invalid_token_format", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		result, err := provider.VerifyToken(context.Background(), "invalid-format-token")
+
+		assert.NoError(t, err)
+		assert.False(t, result.IsValid)
+	})
+
+	t.Run("failure_server_error", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		_, err := provider.VerifyToken(context.Background(), "token")
+
+		assert.Error(t, err)
+	})
+
+	t.Run("success_valid_token_with_details", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "Bearer valid-token", r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"sub":            "user-123",
+				"email":          "test@example.com",
+				"email_verified": true,
+			})
+		})
+
+		result, err := provider.VerifyToken(context.Background(), "valid-token")
+
+		assert.NoError(t, err)
+		assert.True(t, result.IsValid)
+		assert.NotZero(t, result.ExpiresAt)
+	})
+
+	t.Run("failure_empty_token", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		_, err := provider.VerifyToken(context.Background(), "")
+		assert.Error(t, err)
+	})
+
+	t.Run("failure_malformed_token", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		_, err := provider.VerifyToken(context.Background(), "invalid.jwt.token")
+		assert.Error(t, err)
+	})
+
+	t.Run("failure_network_timeout", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(200 * time.Millisecond)
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		_, err := provider.VerifyToken(ctx, "valid-token")
+		assert.Error(t, err)
+	})
+}
+
+func TestExchangeAuthorizationCode(t *testing.T) {
+	t.Run("success_with_pkce", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "test-verifier", r.FormValue("code_verifier"))
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "new-token",
+				"refresh_token": "refresh-token",
+				"id_token":      "id-token",
+				"expires_in":    3600,
+				"token_type":    "Bearer",
+			})
+		})
+
+		tokenInfo, err := provider.ExchangeAuthorizationCode(
+			context.Background(),
+			"code",
+			"http://localhost/callback",
+			"test-verifier",
+			model.IdentityProviderGoogle,
+		)
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, tokenInfo.AccessToken)
+		assert.NotEmpty(t, tokenInfo.RefreshToken)
+		assert.NotEmpty(t, tokenInfo.IDToken)
+	})
+
+	t.Run("failure_invalid_code", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"error":             "invalid_grant",
+				"error_description": "Invalid authorization code",
+			})
+		})
+
+		_, err := provider.ExchangeAuthorizationCode(
+			context.Background(),
+			"invalid-code",
+			"http://localhost/callback",
+			"test-verifier",
+			model.IdentityProviderGoogle,
+		)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("success_complete_response", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "test-verifier", r.FormValue("code_verifier"))
+			assert.Equal(t, "authorization_code", r.FormValue("grant_type"))
+			assert.Equal(t, "test-code", r.FormValue("code"))
+
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "new-access-token",
+				"refresh_token": "new-refresh-token",
+				"id_token":      "new-id-token",
+				"expires_in":    3600,
+				"token_type":    "Bearer",
+				"scope":         "openid profile email",
+			})
+		})
+
+		tokenInfo, err := provider.ExchangeAuthorizationCode(
+			context.Background(),
+			"test-code",
+			"http://localhost/callback",
+			"test-verifier",
+			model.IdentityProviderGoogle,
+		)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "new-access-token", tokenInfo.AccessToken)
+		assert.Equal(t, "new-refresh-token", tokenInfo.RefreshToken)
+		assert.Equal(t, "new-id-token", tokenInfo.IDToken)
+		assert.Equal(t, int64(3600), tokenInfo.ExpiresIn)
+	})
+
+	t.Run("failure_invalid_code_with_error_details", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"error":             "invalid_grant",
+				"error_description": "Invalid authorization code",
+				"error_uri":         "https://auth0.com/docs/errors",
+			})
+		})
+
+		_, err := provider.ExchangeAuthorizationCode(
+			context.Background(),
+			"invalid-code",
+			"http://localhost/callback",
+			"test-verifier",
+			model.IdentityProviderGoogle,
+		)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid_grant")
+	})
+
+	t.Run("failure_missing_required_fields", func(t *testing.T) {
+		provider, server := setupTest(t)
+		defer server.Close()
+
+		server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			// アクセストークンが欠落したレスポンス
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"token_type": "Bearer",
+				"expires_in": 3600,
+			})
+		})
+
+		_, err := provider.ExchangeAuthorizationCode(
+			context.Background(),
+			"test-code",
+			"http://localhost/callback",
+			"test-verifier",
+			model.IdentityProviderGoogle,
+		)
+
+		assert.Error(t, err)
+	})
+}
+
+func TestTestHelpers(t *testing.T) {
+	t.Run("test_server_initialization", func(t *testing.T) {
+		server := newTestServer()
+		defer server.Close()
+
+		assert.NotNil(t, server)
+		assert.Equal(t, 0, server.requestCount)
+		assert.Empty(t, server.requestLog)
+	})
+
+	t.Run("test_server_request_tracking", func(t *testing.T) {
+		server := newTestServer()
+		defer server.Close()
+
+		paths := []string{"/test1", "/test2", "/test3"}
+		for _, path := range paths {
+			resp, err := http.Get(server.URL + path)
+			assert.NoError(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		}
+
+		assert.Equal(t, len(paths), server.requestCount)
+		assert.Equal(t, paths, server.requestLog)
+	})
+
+	t.Run("test_server_concurrent_requests", func(t *testing.T) {
+		server := newTestServer()
+		defer server.Close()
+
+		const numRequests = 10
+		done := make(chan bool)
+
+		for i := 0; i < numRequests; i++ {
+			go func(index int) {
+				path := fmt.Sprintf("/test%d", index)
+				resp, err := http.Get(server.URL + path)
+				assert.NoError(t, err)
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				done <- true
+			}(i)
+		}
+
+		// 全リクエストの完了を待つ
+		for i := 0; i < numRequests; i++ {
+			<-done
+		}
+
+		assert.Equal(t, numRequests, server.requestCount)
+		assert.Equal(t, numRequests, len(server.requestLog))
+	})
+}


### PR DESCRIPTION
## Summary by Sourcery

テスト:
- Auth0プロバイダーのユニットテストを追加。以下のようなさまざまなシナリオをカバーしています：
  - 認証URLの生成
  - ユーザー情報の取得
  - トークンのリフレッシュ
  - 多要素認証（MFA）操作
  - コンテキストのキャンセル
  - エッジケース
  - トークン検証
  - 認証コードの交換

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Added unit tests for the Auth0 provider, covering various scenarios like generating authorization URLs, retrieving user information, refreshing tokens, MFA operations, context cancellation, edge cases, token verification, and exchanging authorization codes.

</details>